### PR TITLE
Fix filter input issue

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -232,7 +232,7 @@ function ConfigureField({
                 : type
             }
             value={value}
-            multi={op === 'oneOf' || op === 'notOneOf'}
+            multi={op === 'oneOf' || op === 'notOneOf' || op === 'hasTags'}
             op={op}
             style={{ marginTop: 10 }}
             onChange={v => {

--- a/upcoming-release-notes/5227.md
+++ b/upcoming-release-notes/5227.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [cursor]
+---
+
+Fix "has tag(s)" filter to work properly when pressing Enter key instead of clicking Apply button


### PR DESCRIPTION
- Added 'hasTags' to multi-value condition in FiltersMenu.jsx
- This allows users to press Enter to apply 'has tag(s)' filters
- Previously only clicking Apply button worked due to missing multi condition

Fixes the issue where pressing Enter on 'has tag(s)' filter would ignore entered hashtag values or show '(nothing)' error.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
