### PR TITLE
Investigate tax calculator bug

### DIFF
--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -791,6 +791,41 @@ describe('Rule', () => {
       );
     });
 
+    test('fixed-percent should balance transaction when percentages sum to 100%', () => {
+      const rule = new Rule({
+        conditionsOp: 'and',
+        conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],
+        actions: [
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            value: 33.33,
+            options: { splitIndex: 1, method: 'fixed-percent' },
+          },
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            value: 33.33,
+            options: { splitIndex: 2, method: 'fixed-percent' },
+          },
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            value: 33.34,
+            options: { splitIndex: 3, method: 'fixed-percent' },
+          },
+        ],
+      });
+
+      const result = rule.exec({ imported_payee: 'James', amount: 1000 });
+      const total = result.subtransactions.reduce(
+        (sum, t) => sum + t.amount,
+        0,
+      );
+      expect(total).toBe(1000);
+      expect(result.error).toBeNull();
+    });
+
     test('generate errors when fixed amounts exceed the total', () => {
       expect(
         fixedAmountRule.exec({ imported_payee: 'James', amount: 100 }),

--- a/packages/loot-core/src/server/rules/index.ts
+++ b/packages/loot-core/src/server/rules/index.ts
@@ -793,14 +793,20 @@ function execSplitActions(actions: Action[], transaction) {
 
   // Distribute to fixed-percent splits.
   const remainingAfterFixedAmounts = getSplitRemainder(newTransactions);
-  splitAmountActions
-    .filter(action => action.options.method === 'fixed-percent')
-    .forEach(action => {
-      const splitTransactionIndex = (action.options?.splitIndex ?? 0) + 1;
-      const percent = action.value / 100;
-      const amount = Math.round(remainingAfterFixedAmounts * percent);
-      newTransactions[splitTransactionIndex].amount = amount;
-    });
+  const fixedPercentActions = splitAmountActions.filter(
+    action => action.options.method === 'fixed-percent',
+  );
+  let lastFixedPercentTransactionIndex = -1;
+  fixedPercentActions.forEach(action => {
+    const splitTransactionIndex = (action.options?.splitIndex ?? 0) + 1;
+    const percent = action.value / 100;
+    const amount = Math.round(remainingAfterFixedAmounts * percent);
+    newTransactions[splitTransactionIndex].amount = amount;
+    lastFixedPercentTransactionIndex = Math.max(
+      lastFixedPercentTransactionIndex,
+      splitTransactionIndex,
+    );
+  });
 
   // Distribute to remainder splits.
   const remainderActions = splitAmountActions.filter(
@@ -823,6 +829,11 @@ function execSplitActions(actions: Action[], transaction) {
 
     // The last remainder split will be adjusted for any leftovers from rounding.
     newTransactions[lastNonFixedTransactionIndex].amount +=
+      getSplitRemainder(newTransactions);
+  } else if (lastFixedPercentTransactionIndex !== -1) {
+    // If there are no remainder splits, adjust the last fixed-percent split
+    // for any leftovers from rounding.
+    newTransactions[lastFixedPercentTransactionIndex].amount +=
       getSplitRemainder(newTransactions);
   }
 

--- a/upcoming-release-notes/5227.md
+++ b/upcoming-release-notes/5227.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [cursor]
+---
+
+Fix rounding errors in fixed-percent split amount rules when multiple percentages sum to 100%. The last fixed-percent split now receives any rounding adjustment to ensure the transaction balances correctly.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fixes a bug in fixed-percent split amount rules where rounding errors could cause transactions to not balance correctly when multiple percentages summed to 100%.

Previously, each fixed-percent split was rounded independently, leading to accumulated discrepancies (e.g., $999 total for a $1000 transaction). This PR introduces an adjustment to the last fixed-percent split to absorb any rounding leftovers, ensuring the total split amount always matches the original transaction. This mirrors the existing rounding logic for remainder splits.

---
[Slack Thread](https://avo-co-24.slack.com/archives/C09KHBF5XNE/p1761273696665539?thread_ts=1761273696.665539&cid=C09KHBF5XNE)

<a href="https://cursor.com/background-agent?bcId=bc-189293bf-2371-4994-bf53-cb4cac43f119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-189293bf-2371-4994-bf53-cb4cac43f119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

